### PR TITLE
Add Disable Password Autofill

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,20 @@ app.deleteAndLaunch(withSpringboardAppName: "TestApp")
 ```
 
 
+### Disable Password Autofill
+
+The iOS Simulator has enabled password autofill by default, which can interfere with text entry in password fields in UI tests. The `XCTestCase` extension provides the `disablePasswordAutofill` to navigate to the settings app and disable password autofill.
+```swift
+class TestAppUITests: XCTestCase {
+    func testDeleteAndLaunch() throws {
+        disablePasswordAutofill()
+        
+        // ...
+    }
+}
+```
+
+
 ### Text Entry
 
 Allows a simple extension on `XCUIElement` to delete and type text in a text field or secure text field.

--- a/Sources/XCTestExtensions/XCTestCase+DisablePasswordAutofill.swift
+++ b/Sources/XCTestExtensions/XCTestCase+DisablePasswordAutofill.swift
@@ -1,0 +1,39 @@
+//
+// This source file is part of the XCTestExtensions open source project
+//
+// SPDX-FileCopyrightText: 2022 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+import XCTest
+
+
+extension XCTestCase {
+    /// Navigates to the iOS settings app and disables the password autofill functionality.
+    public func disablePasswordAutofill() {
+        let settingsApp = XCUIApplication(bundleIdentifier: "com.apple.Preferences")
+        settingsApp.terminate()
+        settingsApp.launch()
+        
+        if settingsApp.staticTexts["PASSWORDS"].waitForExistence(timeout: 0.5) {
+            settingsApp.staticTexts["PASSWORDS"].tap()
+        }
+        
+        let springboard = XCUIApplication(bundleIdentifier: "com.apple.springboard")
+        if springboard.secureTextFields["Passcode field"].waitForExistence(timeout: 20) {
+            let passcodeInput = springboard.secureTextFields["Passcode field"]
+            passcodeInput.tap()
+            passcodeInput.typeText("1234\r")
+        } else {
+            XCTFail("Could not enter the passcode in the device to enter the password section in the settings app.")
+            return
+        }
+        
+        XCTAssertTrue(settingsApp.tables.cells["PasswordOptionsCell"].waitForExistence(timeout: 5.0))
+        settingsApp.tables.cells["PasswordOptionsCell"].buttons["chevron"].tap()
+        if settingsApp.switches["AutoFill Passwords"].value as? String == "1" {
+            settingsApp.switches["AutoFill Passwords"].tap()
+        }
+    }
+}

--- a/Sources/XCTestExtensions/XCTestCase+DisablePasswordAutofill.swift
+++ b/Sources/XCTestExtensions/XCTestCase+DisablePasswordAutofill.swift
@@ -16,12 +16,12 @@ extension XCTestCase {
         settingsApp.terminate()
         settingsApp.launch()
         
-        if settingsApp.staticTexts["PASSWORDS"].waitForExistence(timeout: 0.5) {
+        if settingsApp.staticTexts["PASSWORDS"].waitForExistence(timeout: 5.0) {
             settingsApp.staticTexts["PASSWORDS"].tap()
         }
         
         let springboard = XCUIApplication(bundleIdentifier: "com.apple.springboard")
-        if springboard.secureTextFields["Passcode field"].waitForExistence(timeout: 20) {
+        if springboard.secureTextFields["Passcode field"].waitForExistence(timeout: 30.0) {
             let passcodeInput = springboard.secureTextFields["Passcode field"]
             passcodeInput.tap()
             passcodeInput.typeText("1234\r")
@@ -30,7 +30,7 @@ extension XCTestCase {
             return
         }
         
-        XCTAssertTrue(settingsApp.tables.cells["PasswordOptionsCell"].waitForExistence(timeout: 5.0))
+        XCTAssertTrue(settingsApp.tables.cells["PasswordOptionsCell"].waitForExistence(timeout: 10.0))
         settingsApp.tables.cells["PasswordOptionsCell"].buttons["chevron"].tap()
         if settingsApp.switches["AutoFill Passwords"].value as? String == "1" {
             settingsApp.switches["AutoFill Passwords"].tap()

--- a/Sources/XCTestExtensions/XCTestExtensions.docc/XCTestExtensions.md
+++ b/Sources/XCTestExtensions/XCTestExtensions.docc/XCTestExtensions.md
@@ -25,6 +25,20 @@ app.deleteAndLaunch(withSpringboardAppName: "TestApp")
 ```
 
 
+### Disable Password Autofill
+
+The iOS Simulator has enabled password autofill by default, which can interfere with text entry in password fields in UI tests. The `XCTestCase` extension provides the `disablePasswordAutofill` to navigate to the settings app and disable password autofill.
+```swift
+class TestAppUITests: XCTestCase {
+    func testDeleteAndLaunch() throws {
+        disablePasswordAutofill()
+        
+        // ...
+    }
+}
+```
+
+
 ### Text Entry
 
 Allows a simple extension on `XCUIElement` to delete and type text in a text field or secure text field.

--- a/Tests/UITests/TestAppUITests/TestAppUITests.swift
+++ b/Tests/UITests/TestAppUITests/TestAppUITests.swift
@@ -12,8 +12,9 @@ import XCTestExtensions
 
 class TestAppUITests: XCTestCase {
     func testDeleteAndLaunch() throws {
-        let app = XCUIApplication()
+        disablePasswordAutofill()
         
+        let app = XCUIApplication()
         app.deleteAndLaunch(withSpringboardAppName: "TestApp")
         
         XCTAssert(app.staticTexts["No text set ..."].waitForExistence(timeout: 0.5))


### PR DESCRIPTION
# Add Disable Password Autofill

## :recycle: Current situation & Problem
The iOS Simulator has enabled password autofill by default, which can interfere with text entry in password fields in UI tests.

## :bulb: Proposed solution
The `XCTestCase` extension provides the `disablePasswordAutofill` to navigate to the settings app and disable password autofill.

### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).

