### PR TITLE
Handle Flaky Text Entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,9 @@ secureTextField.enter(value: "Secure Text")
 secureTextField.delete(count: 5)
 ```
 
+Unfortunately, the iOS simulator sometimes has flaky behavior when entering text in a simulator with low computation resources.
+The `enter(value:)` and `delete(count:)` methods provide the `checkIfTextWasEnteredCorrectly` and `checkIfTextWasDeletedCorrectly` parameters that are set to true by default to check if the values were entered correctly. If your text entry does fail to do so, e.g., an entry in a secure text field, set the `checkIfTextWasEnteredCorrectly` or `checkIfTextWasDeletedCorrectly` parameters to `false`. 
+
 
 ## Installation
 

--- a/Sources/XCTestExtensions/XCTestExtensions.docc/XCTestExtensions.md
+++ b/Sources/XCTestExtensions/XCTestExtensions.docc/XCTestExtensions.md
@@ -53,3 +53,6 @@ let secureTextField = app.secureTextFields["SecureField"]
 secureTextField.enter(value: "Secure Text")
 secureTextField.delete(count: 5)
 ```
+
+Unfortunately, the iOS simulator sometimes has flaky behavior when entering text in a simulator with low computation resources.
+The `enter(value:)` and `delete(count:)` methods provide the `checkIfTextWasEnteredCorrectly` and `checkIfTextWasDeletedCorrectly` parameters that are set to true by default to check if the values were entered correctly. If your text entry does fail to do so, e.g., an entry in a secure text field, set the `checkIfTextWasEnteredCorrectly` or `checkIfTextWasDeletedCorrectly` parameters to `false`. 

--- a/Sources/XCTestExtensions/XCUIElement+TextEntry.swift.swift
+++ b/Sources/XCTestExtensions/XCUIElement+TextEntry.swift.swift
@@ -8,21 +8,144 @@
 
 import XCTest
 
-    
+
+/// An internal flag that is used to test the flaky simulator text entry behaviour in the iOS simulator.
+///
+/// Do not use this flag outside of the UI tests in the ``XCTestExtensions`` target!
+var simulateFlakySimulatorTextEntry = false
+
+
 extension XCUIElement {
     /// Delete a fixed number of characters in a text field or secure text field.
     /// - Parameter count: The number of characters that should be deleted.
-    public func delete(count: Int) {
-        coordinate(withNormalizedOffset: CGVector(dx: 0.99, dy: 0.5)).tap()
-        XCTAssert(XCUIApplication().keyboards.firstMatch.waitForExistence(timeout: 2.0))
-        typeText(String(repeating: XCUIKeyboardKey.delete.rawValue, count: count))
+    /// - Parameter checkIfTextWasDeletedCorrectly: Check if the text was deleted correctly.
+    ///
+    /// Unfortunately, the iOS simulator sometimes has flaky behavior when entering text in a simulator with low computation resources.
+    /// The method provides the `checkIfTextWasDeletedCorrectly` parameter that is set to true by default to check if the characters were deleted correctly.
+    /// If your text entry does fail to do so, e.g., a deletion in a secure text field, set the `checkIfTextWasDeletedCorrectly` parameter to `false`.
+    public func delete(count: Int, checkIfTextWasDeletedCorrectly: Bool = true) {
+        delete(count: count, checkIfTextWasDeletedCorrectly: checkIfTextWasDeletedCorrectly, recursiveDepth: 0)
     }
     
     /// Type a text in a text field or secure text field.
-    /// - Parameter value: The text that should be typed.
-    public func enter(value: String) {
-        tap()
+    /// - Parameter newValue: The text that should be typed.
+    /// - Parameter checkIfTextWasEnteredCorrectly: Check if the text was entered correctly.
+    ///
+    /// Unfortunately, the iOS simulator sometimes has flaky behavior when entering text in a simulator with low computation resources.
+    /// The method provides the `checkIfTextWasEnteredCorrectly` parameter that is set to true by default to check if the characters were entered correctly.
+    /// If your text entry does fail to do so, e.g., an entry in a secure text field, set the `checkIfTextWasEnteredCorrectly` parameter to `false`.
+    public func enter(value newValue: String, checkIfTextWasEnteredCorrectly: Bool = true) {
+        enter(value: newValue, checkIfTextWasEnteredCorrectly: checkIfTextWasEnteredCorrectly, recursiveDepth: 0)
+    }
+    
+    
+    private func delete( // swiftlint:disable:this function_default_parameter_at_end
+        count: Int,
+        checkIfTextWasDeletedCorrectly: Bool = true,
+        // We put this paramter at the end of the function to mimic the public interface with an internal extension.
+        recursiveDepth: Int
+    ) {
+        guard recursiveDepth <= 2 else {
+            XCTFail("Could not successfully delete \(count) characters in the textfield \(self.debugDescription)")
+            return
+        }
+        
+        // Get the current value so we can assert if the text deleted was correct.
+        let currentValueCount: Int
+        if value as? String == placeholderValue {
+            // If the value is the placeholderValue we assume that the text field has no value entered.
+            currentValueCount = 0
+        } else {
+            currentValueCount = (value as? String ?? "").count
+        }
+        
+        coordinate(withNormalizedOffset: CGVector(dx: 0.99, dy: 0.5)).tap()
         XCTAssert(XCUIApplication().keyboards.firstMatch.waitForExistence(timeout: 2.0))
-        typeText(value)
+        if simulateFlakySimulatorTextEntry && recursiveDepth < 2 {
+            typeText(String(repeating: XCUIKeyboardKey.delete.rawValue, count: count - 1))
+        } else {
+            typeText(String(repeating: XCUIKeyboardKey.delete.rawValue, count: count))
+        }
+        
+        // Check of the text was deleted correctly:
+        if checkIfTextWasDeletedCorrectly {
+            let countAfterDeletion = (value as? String ?? "").count
+            
+            if currentValueCount - count < countAfterDeletion {
+                delete(
+                    count: countAfterDeletion - (currentValueCount - count),
+                    checkIfTextWasDeletedCorrectly: true,
+                    recursiveDepth: recursiveDepth + 1
+                )
+            }
+        }
+    }
+    
+    private func enter( // swiftlint:disable:this function_default_parameter_at_end
+        value textToEnter: String,
+        checkIfTextWasEnteredCorrectly: Bool = true,
+        // We put this paramter at the end of the function to mimic the public interface with an internal extension.
+        recursiveDepth: Int
+    ) {
+        guard recursiveDepth <= 2 else {
+            XCTFail("Could not successfully verify entering \"\(textToEnter)\" in the textfield \(self.debugDescription)")
+            return
+        }
+        
+        // Get the current value so we can assert if the text entry was correct.
+        let currentValue: String
+        if value as? String == placeholderValue {
+            // If the value is the placeholderValue we assume that the text field has no value entered.
+            currentValue = ""
+        } else {
+            currentValue = value as? String ?? ""
+        }
+        
+        // Enter the value
+        coordinate(withNormalizedOffset: CGVector(dx: 0.99, dy: 0.5)).tap()
+        XCTAssert(XCUIApplication().keyboards.firstMatch.waitForExistence(timeout: 2.0))
+        if simulateFlakySimulatorTextEntry && recursiveDepth < 2 {
+            typeText(String(textToEnter.dropLast(1)))
+        } else {
+            typeText(textToEnter)
+        }
+        
+        // Check of the text was entered correctly:
+        if checkIfTextWasEnteredCorrectly {
+            let valueAfterTextEntry = value as? String ?? ""
+            
+            if self.elementType == .secureTextField {
+                if currentValue.isEmpty && textToEnter.count != valueAfterTextEntry.count {
+                    // We delete the text twice to ensure that we have an empty text field even if the textfield might go byeond the current scope
+                    delete(count: valueAfterTextEntry.count, checkIfTextWasDeletedCorrectly: false)
+                    delete(count: valueAfterTextEntry.count, checkIfTextWasDeletedCorrectly: false)
+                    
+                    enter(
+                        value: currentValue + textToEnter,
+                        checkIfTextWasEnteredCorrectly: true,
+                        recursiveDepth: recursiveDepth + 1
+                    )
+                } else if currentValue.count + textToEnter.count != valueAfterTextEntry.count {
+                    XCTFail(
+                        """
+                        The text entered in the secure text field doesn't seem to match the desired length.
+                        We can not re-enter the value as we don't have an insight into the value that was present in the secure text field before.
+                        """
+                    )
+                }
+            } else {
+                if currentValue + textToEnter != valueAfterTextEntry {
+                    // We delete the text twice to ensure that we have an empty text field even if the textfield might go byeond the current scope
+                    delete(count: valueAfterTextEntry.count, checkIfTextWasDeletedCorrectly: false)
+                    delete(count: valueAfterTextEntry.count, checkIfTextWasDeletedCorrectly: false)
+                    
+                    enter(
+                        value: currentValue + textToEnter,
+                        checkIfTextWasEnteredCorrectly: true,
+                        recursiveDepth: recursiveDepth + 1
+                    )
+                }
+            }
+        }
     }
 }

--- a/Tests/UITests/TestApp.xctestplan
+++ b/Tests/UITests/TestApp.xctestplan
@@ -1,0 +1,28 @@
+{
+  "configurations" : [
+    {
+      "id" : "33D2410E-1738-4ECB-8413-855785357B28",
+      "name" : "Default",
+      "options" : {
+
+      }
+    }
+  ],
+  "defaultOptions" : {
+    "targetForVariableExpansion" : {
+      "containerPath" : "container:UITests.xcodeproj",
+      "identifier" : "2F6D139128F5F384007C25D6",
+      "name" : "TestApp"
+    }
+  },
+  "testTargets" : [
+    {
+      "target" : {
+        "containerPath" : "container:UITests.xcodeproj",
+        "identifier" : "2F6D13AB28F5F386007C25D6",
+        "name" : "TestAppUITests"
+      }
+    }
+  ],
+  "version" : 1
+}

--- a/Tests/UITests/TestApp.xctestplan.license
+++ b/Tests/UITests/TestApp.xctestplan.license
@@ -1,0 +1,5 @@
+This source file is part of the XCTestExtensions open-source project
+
+SPDX-FileCopyrightText: 2022 Stanford University and the project authors (see CONTRIBUTORS.md)
+
+SPDX-License-Identifier: MIT

--- a/Tests/UITests/TestAppUITests/TestAppUITests.swift
+++ b/Tests/UITests/TestAppUITests/TestAppUITests.swift
@@ -50,11 +50,19 @@ extension XCUIApplication {
         textField.delete(count: 5)
         XCTAssert(staticTexts["Example"].waitForExistence(timeout: 5.0))
         
+        textField.delete(count: 42)
+        XCTAssert(staticTexts["No text set ..."].waitForExistence(timeout: 5.0))
+        
+        swipeUp()
+        
         XCTAssert(staticTexts["No secure text set ..."].waitForExistence(timeout: 5.0))
         let secureTextField = secureTextFields["SecureField"]
         secureTextField.enter(value: "Secure Text")
         XCTAssert(staticTexts["Secure Text"].waitForExistence(timeout: 5.0))
         secureTextField.delete(count: 5)
         XCTAssert(staticTexts["Secure"].waitForExistence(timeout: 5.0))
+        
+        secureTextField.delete(count: 42)
+        XCTAssert(staticTexts["No secure text set ..."].waitForExistence(timeout: 5.0))
     }
 }

--- a/Tests/UITests/TestAppUITests/TestAppUITests.swift
+++ b/Tests/UITests/TestAppUITests/TestAppUITests.swift
@@ -7,29 +7,54 @@
 //
 
 import XCTest
-import XCTestExtensions
+@testable import XCTestExtensions
 
 
 class TestAppUITests: XCTestCase {
     func testDeleteAndLaunch() throws {
-        disablePasswordAutofill()
-        
         let app = XCUIApplication()
         app.deleteAndLaunch(withSpringboardAppName: "TestApp")
         
-        XCTAssert(app.staticTexts["No text set ..."].waitForExistence(timeout: 0.5))
-        let textField = app.textFields["TextField"]
+        XCTAssert(app.staticTexts["No text set ..."].waitForExistence(timeout: 5.0))
+        XCTAssert(app.staticTexts["No secure text set ..."].waitForExistence(timeout: 5.0))
+    }
+    
+    func testDisablePasswordAutofill() throws {
+        disablePasswordAutofill()
+    }
+    
+    func testTextEntry() throws {
+        let app = XCUIApplication()
+        app.launch()
+        
+        simulateFlakySimulatorTextEntry = false
+        app.callTextEntryExtensions()
+    }
+    
+    func testFlakyTextEntry() throws {
+        let app = XCUIApplication()
+        app.launch()
+        
+        simulateFlakySimulatorTextEntry = true
+        app.callTextEntryExtensions()
+    }
+}
+
+
+extension XCUIApplication {
+    fileprivate func callTextEntryExtensions() {
+        XCTAssert(staticTexts["No text set ..."].waitForExistence(timeout: 5.0))
+        let textField = textFields["TextField"]
         textField.enter(value: "Example Text")
-        XCTAssert(app.staticTexts["Example Text"].waitForExistence(timeout: 0.5))
+        XCTAssert(staticTexts["Example Text"].waitForExistence(timeout: 5.0))
         textField.delete(count: 5)
-        XCTAssert(app.staticTexts["Example"].waitForExistence(timeout: 0.5))
+        XCTAssert(staticTexts["Example"].waitForExistence(timeout: 5.0))
         
-        XCTAssert(app.staticTexts["No secure text set ..."].waitForExistence(timeout: 0.5))
-        
-        let secureTextField = app.secureTextFields["SecureField"]
+        XCTAssert(staticTexts["No secure text set ..."].waitForExistence(timeout: 5.0))
+        let secureTextField = secureTextFields["SecureField"]
         secureTextField.enter(value: "Secure Text")
-        XCTAssert(app.staticTexts["Secure Text"].waitForExistence(timeout: 0.5))
+        XCTAssert(staticTexts["Secure Text"].waitForExistence(timeout: 5.0))
         secureTextField.delete(count: 5)
-        XCTAssert(app.staticTexts["Secure"].waitForExistence(timeout: 0.5))
+        XCTAssert(staticTexts["Secure"].waitForExistence(timeout: 5.0))
     }
 }

--- a/Tests/UITests/UITests.xcodeproj/project.pbxproj
+++ b/Tests/UITests/UITests.xcodeproj/project.pbxproj
@@ -31,6 +31,7 @@
 		2F6D13AC28F5F386007C25D6 /* TestAppUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = TestAppUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		2F8A431229130A8C005D2B8F /* TestAppUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestAppUITests.swift; sourceTree = "<group>"; };
 		2FA7382B290ADFAA007ACEB9 /* TestApp.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestApp.swift; sourceTree = "<group>"; };
+		2FE5AAA829985FD9004A0442 /* TestApp.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = TestApp.xctestplan; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -55,6 +56,7 @@
 		2F6D138928F5F384007C25D6 = {
 			isa = PBXGroup;
 			children = (
+				2FE5AAA829985FD9004A0442 /* TestApp.xctestplan */,
 				2F68C3C6292E9F8F00B3E12C /* XCTestExtensions */,
 				2F6D139428F5F384007C25D6 /* TestApp */,
 				2F6D13AF28F5F386007C25D6 /* TestAppUITests */,

--- a/Tests/UITests/UITests.xcodeproj/xcshareddata/xcschemes/TestApp.xcscheme
+++ b/Tests/UITests/UITests.xcodeproj/xcshareddata/xcschemes/TestApp.xcscheme
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
    LastUpgradeVersion = "1410"
-   version = "1.3">
+   version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">
@@ -37,6 +37,12 @@
             ReferencedContainer = "container:../..">
          </BuildableReference>
       </CodeCoverageTargets>
+      <TestPlans>
+         <TestPlanReference
+            reference = "container:TestApp.xctestplan"
+            default = "YES">
+         </TestPlanReference>
+      </TestPlans>
       <Testables>
          <TestableReference
             skipped = "NO">


### PR DESCRIPTION
# Handle Flaky Text Entry

## :recycle: Current situation & Problem
Unfortunately, the iOS simulator sometimes has flaky behavior when entering text in a simulator with low computation resources.

## :bulb: Proposed solution
The `enter(value:)` and `delete(count:)` methods now provide the `checkIfTextWasEnteredCorrectly` and `checkIfTextWasDeletedCorrectly` parameters that are set to true by default to check if the values were entered correctly. If your text entry does fail to do so, e.g., an entry in a secure text field, set the `checkIfTextWasEnteredCorrectly` or `checkIfTextWasDeletedCorrectly` parameters to `false`. 

### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).

