### PR TITLE
Make Functions Throwing to Catch Errors in the UI Tests

### DIFF
--- a/Sources/XCTestExtensions/XCTestCase+DisablePasswordAutofill.swift
+++ b/Sources/XCTestExtensions/XCTestCase+DisablePasswordAutofill.swift
@@ -6,12 +6,13 @@
 // SPDX-License-Identifier: MIT
 //
 
+import OSLog
 import XCTest
 
 
 extension XCTestCase {
     /// Navigates to the iOS settings app and disables the password autofill functionality.
-    public func disablePasswordAutofill() {
+    public func disablePasswordAutofill() throws {
         let settingsApp = XCUIApplication(bundleIdentifier: "com.apple.Preferences")
         settingsApp.terminate()
         settingsApp.launch()
@@ -26,8 +27,8 @@ extension XCTestCase {
             passcodeInput.tap()
             passcodeInput.typeText("1234\r")
         } else {
-            XCTFail("Could not enter the passcode in the device to enter the password section in the settings app.")
-            return
+            os_log("Could not enter the passcode in the device to enter the password section in the settings app.")
+            throw XCTestError(.failureWhileWaiting)
         }
         
         XCTAssertTrue(settingsApp.tables.cells["PasswordOptionsCell"].waitForExistence(timeout: 10.0))

--- a/Tests/UITests/TestAppUITests/TestAppUITests.swift
+++ b/Tests/UITests/TestAppUITests/TestAppUITests.swift
@@ -32,7 +32,7 @@ class TestAppUITests: XCTestCase {
     }
     
     func testDisablePasswordAutofill() throws {
-        disablePasswordAutofill()
+        try disablePasswordAutofill()
     }
     
     func testTextEntry() throws {
@@ -40,7 +40,7 @@ class TestAppUITests: XCTestCase {
         app.launch()
         
         simulateFlakySimulatorTextEntry = false
-        app.callTextEntryExtensions()
+        try app.callTextEntryExtensions()
     }
     
     func testFlakyTextEntry() throws {
@@ -48,33 +48,33 @@ class TestAppUITests: XCTestCase {
         app.launch()
         
         simulateFlakySimulatorTextEntry = true
-        app.callTextEntryExtensions()
+        try app.callTextEntryExtensions()
     }
 }
 
 
 extension XCUIApplication {
-    fileprivate func callTextEntryExtensions() {
+    fileprivate func callTextEntryExtensions() throws {
         XCTAssert(staticTexts["No text set ..."].waitForExistence(timeout: 5.0))
         let textField = textFields["TextField"]
-        textField.enter(value: "Example Text")
+        try textField.enter(value: "Example Text")
         XCTAssert(staticTexts["Example Text"].waitForExistence(timeout: 5.0))
-        textField.delete(count: 5)
+        try textField.delete(count: 5)
         XCTAssert(staticTexts["Example"].waitForExistence(timeout: 5.0))
         
-        textField.delete(count: 42)
+        try textField.delete(count: 42)
         XCTAssert(staticTexts["No text set ..."].waitForExistence(timeout: 5.0))
         
         swipeUp()
         
         XCTAssert(staticTexts["No secure text set ..."].waitForExistence(timeout: 5.0))
         let secureTextField = secureTextFields["SecureField"]
-        secureTextField.enter(value: "Secure Text")
+        try secureTextField.enter(value: "Secure Text")
         XCTAssert(staticTexts["Secure Text"].waitForExistence(timeout: 5.0))
-        secureTextField.delete(count: 5)
+        try secureTextField.delete(count: 5)
         XCTAssert(staticTexts["Secure"].waitForExistence(timeout: 5.0))
         
-        secureTextField.delete(count: 42)
+        try secureTextField.delete(count: 42)
         XCTAssert(staticTexts["No secure text set ..."].waitForExistence(timeout: 5.0))
     }
 }


### PR DESCRIPTION
# Make Functions Throwing to Catch Errors in the UI Tests

## :recycle: Current situation & Problem
The current functions use `XCFail` to report errors. This makes it hard to recover from failures in a UI test.

## :bulb: Proposed solution
This PR switches to use `os_log` for logging failures and makes the functions throwing to be able to handle errors. 

### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).

