### PR TITLE
Add Option to Dismiss the Keyboard After Text Entry

### DIFF
--- a/Sources/XCTestExtensions/XCUIElement+TextEntry.swift
+++ b/Sources/XCTestExtensions/XCUIElement+TextEntry.swift
@@ -73,7 +73,7 @@ extension XCUIElement {
     }
     
     
-    private func delete( // swiftlint:disable:this function_default_parameter_at_end
+    private func delete(
         count: Int,
         checkIfTextWasDeletedCorrectly: Bool,
         dismissKeyboard: Bool,
@@ -117,7 +117,7 @@ extension XCUIElement {
         }
     }
     
-    private func enter( // swiftlint:disable:this function_default_parameter_at_end
+    private func enter(
         value textToEnter: String,
         checkIfTextWasEnteredCorrectly: Bool,
         dismissKeyboard: Bool,


### PR DESCRIPTION
# Add Option to Dismiss the Keyboard After Text Entry

## :recycle: Current situation & Problem
- Currently there is no option to disable dismissing the keyboard after text has been entered.

## :bulb: Proposed solution
- Adds a argument to disable dismissing the keyboard

### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).

