### PR TITLE
Don't check for keyboard appearing on catalyst

### DIFF
--- a/Sources/XCTestExtensions/XCUIElement+TextEntry.swift
+++ b/Sources/XCTestExtensions/XCUIElement+TextEntry.swift
@@ -202,7 +202,7 @@ extension XCUIElement {
         #if os(visionOS)
         tap()
         _ = app.visionOSKeyboard.waitForExistence(timeout: 2.0) // this will always succeed
-        #elseif os(macOS)
+        #elseif os(macOS) || targetEnvironment(macCatalyst)
         // this should hit the keyboard most likely. The `.keyboard` query doesn't exist on macOS.
         coordinate(withNormalizedOffset: CGVector(dx: 0.95, dy: 0.5)).tap()
         #else


### PR DESCRIPTION
# Don't check for keyboard appearing on catalyst

## :recycle: Current situation & Problem
For our text entry implementation, we currently maintain a special check for `macOS` to not check for keyboard existence (as there is no UI keyboard don macOS). This check currently isn't used on the catalyst platform. This PR fixes that for macOS Catalyst as well.


## :gear: Release Notes 
* Fix text entry for macOS catalyst builds


## :books: Documentation
-- 


## :white_check_mark: Testing
--


### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).
