### PR TITLE
Enable visionOS 2.0 Support for Deleting an App from RealityLauncher

### DIFF
--- a/Sources/XCTestExtensions/XCUIApplication+DeleteAndLaunch.swift
+++ b/Sources/XCTestExtensions/XCUIApplication+DeleteAndLaunch.swift
@@ -26,6 +26,18 @@ extension XCUIApplication {
         preconditionFailure("Unsupported platform.")
 #endif
     }
+    
+    private static var visionOS2: Bool {
+        #if os(visionOS)
+        if #available(visionOS 2.0, *) {
+            true
+        } else {
+            false
+        }
+        #else
+        false
+        #endif
+    }
 
     /// Deletes the application from the iOS springboard (iOS home screen) and launches it after it has been deleted and reinstalled.
     /// - Parameter appName: The name of the application as displayed on the springboard (iOS home screen).
@@ -49,7 +61,7 @@ extension XCUIApplication {
             XCTAssertTrue(springboard.icons[appName].firstMatch.isHittable)
             springboard.icons[appName].firstMatch.press(forDuration: 1.75)
             
-            if #available(visionOS 2.0, *) {
+            if XCUIApplication.visionOS2 {
                 // VisionOS 2.0 changed the behavior how apps are deleted, showing a delete button above the app icon.
                 sleep(5)
                 let deleteButtons = springboard.collectionViews.buttons.matching(identifier: "Delete")


### PR DESCRIPTION
# Enable visionOS 2.0 Support for Deleting an App from RealityLauncher

## :recycle: Current situation & Problem
- UI tests aiming to delete an app are failing on visionOS 2.0

## :gear: Release Notes 
- Enable visionOS 2.0 Support for Deleting an App from RealityLauncher


### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).
