### PR TITLE
Improve App Deletion on VisionOS and Swift 6

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.9
+// swift-tools-version:6.0
 
 //
 // This source file is part of the Stanford XCTestExtensions open-source project
@@ -8,14 +8,8 @@
 // SPDX-License-Identifier: MIT
 //
 
+import class Foundation.ProcessInfo
 import PackageDescription
-
-
-#if swift(<6)
-let swiftConcurrency: SwiftSetting = .enableExperimentalFeature("StrictConcurrency")
-#else
-let swiftConcurrency: SwiftSetting = .enableUpcomingFeature("StrictConcurrency")
-#endif
 
 
 let package = Package(
@@ -30,27 +24,40 @@ let package = Package(
         .library(name: "XCTestApp", targets: ["XCTestApp"]),
         .library(name: "XCTestExtensions", targets: ["XCTestExtensions"])
     ],
+    dependencies: [] + swiftLintPackage(),
     targets: [
         .target(
             name: "XCTestApp",
-            swiftSettings: [
-                swiftConcurrency
-            ]
+            plugins: [] + swiftLintPlugin()
         ),
         .target(
             name: "XCTestExtensions",
-            swiftSettings: [
-                swiftConcurrency
-            ]
+            plugins: [] + swiftLintPlugin()
         ),
         .testTarget(
             name: "XCTestExtensionsTests",
             dependencies: [
                 .target(name: "XCTestExtensions")
             ],
-            swiftSettings: [
-                swiftConcurrency
-            ]
+            plugins: [] + swiftLintPlugin()
         )
     ]
 )
+
+
+func swiftLintPlugin() -> [Target.PluginUsage] {
+    // Fully quit Xcode and open again with `open --env SPEZI_DEVELOPMENT_SWIFTLINT /Applications/Xcode.app`
+    if ProcessInfo.processInfo.environment["SPEZI_DEVELOPMENT_SWIFTLINT"] != nil {
+        [.plugin(name: "SwiftLintBuildToolPlugin", package: "SwiftLint")]
+    } else {
+        []
+    }
+}
+
+func swiftLintPackage() -> [PackageDescription.Package.Dependency] {
+    if ProcessInfo.processInfo.environment["SPEZI_DEVELOPMENT_SWIFTLINT"] != nil {
+        [.package(url: "https://github.com/realm/SwiftLint.git", from: "0.55.1")]
+    } else {
+        []
+    }
+}

--- a/Sources/XCTestExtensions/XCTestExtensions.docc/XCTestExtensions.md
+++ b/Sources/XCTestExtensions/XCTestExtensions.docc/XCTestExtensions.md
@@ -62,5 +62,6 @@ The `enter(value:)` and `delete(count:)` methods provide the `checkIfTextWasEnte
 ### App Interaction
 
 - ``XCTest/XCUIApplication/deleteAndLaunch(withSpringboardAppName:)``
+- ``XCTest/XCUIApplication/delete(app:)``
 - ``XCTest/XCUIApplication/dismissKeyboard()``
 - ``XCTest/XCUIApplication/homeScreenBundle``

--- a/Tests/UITests/UITests.xcodeproj/project.pbxproj
+++ b/Tests/UITests/UITests.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 56;
+	objectVersion = 77;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -180,7 +180,6 @@
 				};
 			};
 			buildConfigurationList = 2F6D138D28F5F384007C25D6 /* Build configuration list for PBXProject "UITests" */;
-			compatibilityVersion = "Xcode 14.0";
 			developmentRegion = en;
 			hasScannedForEncodings = 0;
 			knownRegions = (
@@ -188,6 +187,7 @@
 				Base,
 			);
 			mainGroup = 2F6D138928F5F384007C25D6;
+			preferredProjectObjectVersion = 77;
 			productRefGroup = 2F6D139328F5F384007C25D6 /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
@@ -307,6 +307,7 @@
 				SDKROOT = iphoneos;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 6.0;
 				XROS_DEPLOYMENT_TARGET = 1.0;
 			};
 			name = Debug;
@@ -362,6 +363,7 @@
 				SDKROOT = iphoneos;
 				SWIFT_COMPILATION_MODE = wholemodule;
 				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				SWIFT_VERSION = 6.0;
 				VALIDATE_PRODUCT = YES;
 				XROS_DEPLOYMENT_TARGET = 1.0;
 			};


### PR DESCRIPTION
# Improve App Deletion on VisionOS and Swift 6

## :recycle: Current situation & Problem
This PR improves app deletion on the visionOS platform. Further, we introduce a new `delete(app:)` version that doesn't launch the application. This is useful if you want to delete the app as a teardown procedure of your application. Instead of deleting the application before your test runs you can delete the application after test that perform state changes on the application.

This feature enables the Swift 6 language mode.


## :gear: Release Notes 
* Added `delete(app:)` extension
* Improved app deletion on visionOS
* Swift 6


## :books: Documentation
Updated new interfaces.


## :white_check_mark: Testing
--

### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).
