### PR TITLE
fix deletion of HealthKit-connected apps

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -30,7 +30,7 @@ jobs:
     with:
       runsonlabels: '["macOS", "self-hosted"]'
       scheme: XCTestExtensions-Package
-      destination: 'platform=watchOS Simulator,name=Apple Watch Series 9 (45mm)'
+      destination: 'platform=watchOS Simulator,name=Apple Watch Series 10 (46mm)'
       resultBundle: XCTestExtensions-watchOS.xcresult
       artifactname: XCTestExtensions-watchOS.xcresult
   buildandtest_visionos:

--- a/Sources/XCTestExtensions/XCUIApplication+DeleteAndLaunch.swift
+++ b/Sources/XCTestExtensions/XCUIApplication+DeleteAndLaunch.swift
@@ -113,6 +113,11 @@ extension XCUIApplication {
 #endif
 
             if springboard.icons[appName].waitForNonExistence(timeout: 2.0) {
+                // If the app had health data stored, deleting the app will show an alert, which we need to dismiss
+                let alertTitle = "There is data from “\(appName)” saved in Health"
+                if springboard.alerts[alertTitle].waitForExistence(timeout: 2) {
+                    springboard.alerts[alertTitle].buttons["OK"].tap()
+                }
                 break
             }
         }

--- a/Tests/UITests/TestApp/HealthKitDataEntry.swift
+++ b/Tests/UITests/TestApp/HealthKitDataEntry.swift
@@ -6,8 +6,8 @@
 // SPDX-License-Identifier: MIT
 //
 
-import SwiftUI
 import HealthKit
+import SwiftUI
 
 
 private let healthStore = HKHealthStore()
@@ -45,6 +45,8 @@ struct HealthKitDataEntryView: View {
             case .sharingAuthorized:
                 hasAccess = true
             case .notDetermined, .sharingDenied: // sharingDenied will never happen in the test environment.
+                hasAccess = false
+            @unknown default:
                 hasAccess = false
             }
         }

--- a/Tests/UITests/TestApp/HealthKitDataEntry.swift
+++ b/Tests/UITests/TestApp/HealthKitDataEntry.swift
@@ -1,0 +1,78 @@
+//
+// This source file is part of the Stanford XCTestExtensions open-source project
+//
+// SPDX-FileCopyrightText: 2025 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+import SwiftUI
+import HealthKit
+
+
+private let healthStore = HKHealthStore()
+
+struct HealthKitDataEntryView: View {
+    @State private var isAddingSample = false
+    @State private var didAddSample = false
+    
+    @State private var hasAccess = false
+    
+    var body: some View {
+        Form {
+            Button("Add a HealthKit sample") {
+                Task {
+                    do {
+                        try await addSample()
+                        didAddSample = true
+                    } catch {
+                        print("Erorr trying to add test sample: \(error)")
+                    }
+                }
+            }.disabled(isAddingSample)
+            
+            Section { // status section
+                if hasAccess {
+                    Text("Has access")
+                }
+                if didAddSample {
+                    Text("Did add sample!")
+                }
+            }
+        }
+        .task {
+            switch healthStore.authorizationStatus(for: HKQuantityType(.heartRate)) {
+            case .sharingAuthorized:
+                hasAccess = true
+            case .notDetermined, .sharingDenied: // sharingDenied will never happen in the test environment.
+                hasAccess = false
+            }
+        }
+    }
+    
+    
+    private func addSample() async throws {
+        isAddingSample = true
+        defer {
+            isAddingSample = false
+        }
+        guard HKHealthStore.isHealthDataAvailable() else {
+            return
+        }
+        
+        let now = Date()
+        let heartRateType = HKQuantityType(.heartRate)
+        
+        try await healthStore.requestAuthorization(toShare: [heartRateType], read: [])
+        let sample = HKQuantitySample(
+            type: heartRateType,
+            quantity: .init(unit: .count().unitDivided(by: .minute()), doubleValue: 69),
+            start: now,
+            end: now,
+            // adding this incase anyone ever runs this on a real device by accicent,
+            // so that they can easily identify and delete any test samples.
+            metadata: ["edu.stanford.BDHG.XCTestExtensions.isTestSample": "1"]
+        )
+        try await healthStore.save(sample)
+    }
+}

--- a/Tests/UITests/TestApp/Info.plist
+++ b/Tests/UITests/TestApp/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>NSHealthUpdateUsageDescription</key>
+	<string>The app adds a sample to the HealthKit database, to fully test app deletion</string>
 	<key>UIApplicationSceneManifest</key>
 	<dict>
 		<key>UIApplicationSupportsMultipleScenes</key>

--- a/Tests/UITests/TestApp/TestApp.entitlements
+++ b/Tests/UITests/TestApp/TestApp.entitlements
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-<dict/>
+<dict>
+	<key>com.apple.developer.healthkit</key>
+	<true/>
+</dict>
 </plist>

--- a/Tests/UITests/TestApp/TestAppTestCaseEnum.swift
+++ b/Tests/UITests/TestApp/TestAppTestCaseEnum.swift
@@ -14,7 +14,7 @@ enum TestAppTestCaseEnum: String, TestAppTests {
     case xcTestApp = "XCTestApp"
     case xcTestExtensions = "XCTestExtensions"
     case dismissKeyboard = "DismissKeyboard"
-    
+    case healthKitDataEntry = "HealthKitDataEntry"
     
     func view(withNavigationPath path: Binding<NavigationPath>) -> some View {
         switch self {
@@ -24,6 +24,8 @@ enum TestAppTestCaseEnum: String, TestAppTests {
             XCTestExtensionsTest()
         case .dismissKeyboard:
             DismissKeyboardTest()
+        case .healthKitDataEntry:
+            HealthKitDataEntryView()
         }
     }
 }

--- a/Tests/UITests/TestAppUITests/XCTestExtensionsTests.swift
+++ b/Tests/UITests/TestAppUITests/XCTestExtensionsTests.swift
@@ -33,7 +33,38 @@ class XCTestExtensionsTests: XCTestCase {
         XCTAssert(app.staticTexts["No text set ..."].waitForExistence(timeout: 5))
         XCTAssert(app.staticTexts["No secure text set ..."].exists)
     }
+    
+    @available(macOS, unavailable)
+    @available(watchOS, unavailable)
+    @available(visionOS, unavailable)
+    @available(tvOS, unavailable)
+    func testDeleteAndLaunchWithHealthKitSample() throws {
+#if os(macOS) || os(watchOS) || os(visionOS) || os(tvOS)
+        throw XCTSkip("Not supported on this platform")
+#endif
 
+        let app = XCUIApplication()
+        app.deleteAndLaunch(withSpringboardAppName: "TestApp")
+        
+        XCTAssert(app.buttons["HealthKitDataEntry"].waitForExistence(timeout: 5.0))
+        app.buttons["HealthKitDataEntry"].tap()
+        
+        XCTAssert(app.buttons["Add a HealthKit sample"].waitForExistence(timeout: 3))
+        app.buttons["Add a HealthKit sample"].tap()
+        
+        if app.staticTexts["Has access"].waitForNonExistence(timeout: 2) {
+            // if the view isn't telling us that it has access, it's currently requesting access
+            app.tables.staticTexts["Turn On All"].tap()
+            app.navigationBars["Health Access"].buttons["Allow"].tap()
+        }
+        
+        XCTAssert(app.staticTexts["Did add sample!"].waitForExistence(timeout: 5))
+        XCTAssert(app.staticTexts["Did add sample!"].exists)
+        
+        app.deleteAndLaunch(withSpringboardAppName: "TestApp")
+    }
+
+    
     @available(macOS, unavailable)
     @available(watchOS, unavailable)
     func testDeleteAndLaunchFromFirstPage() throws {

--- a/Tests/UITests/UITests.xcodeproj/project.pbxproj
+++ b/Tests/UITests/UITests.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		2F87F9EE2952F10600810247 /* XCTestExtensions in Frameworks */ = {isa = PBXBuildFile; productRef = 2F87F9ED2952F10600810247 /* XCTestExtensions */; };
 		2F8A431329130A8C005D2B8F /* XCTestExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F8A431229130A8C005D2B8F /* XCTestExtensionsTests.swift */; };
 		2FA7382C290ADFAA007ACEB9 /* TestApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FA7382B290ADFAA007ACEB9 /* TestApp.swift */; };
+		80A1F4312D393F6800183BFF /* HealthKitDataEntry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80A1F4302D393F6800183BFF /* HealthKitDataEntry.swift */; };
 		A9E8E2552AA375DC0051274C /* DismissKeyboardTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9E8E2542AA375DC0051274C /* DismissKeyboardTest.swift */; };
 /* End PBXBuildFile section */
 
@@ -42,6 +43,8 @@
 		2F8A431229130A8C005D2B8F /* XCTestExtensionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XCTestExtensionsTests.swift; sourceTree = "<group>"; };
 		2FA7382B290ADFAA007ACEB9 /* TestApp.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestApp.swift; sourceTree = "<group>"; };
 		2FE5AAA829985FD9004A0442 /* TestApp.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = TestApp.xctestplan; sourceTree = "<group>"; };
+		80A1F42F2D393F3600183BFF /* TestApp.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = TestApp.entitlements; sourceTree = "<group>"; };
+		80A1F4302D393F6800183BFF /* HealthKitDataEntry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HealthKitDataEntry.swift; sourceTree = "<group>"; };
 		A9E8E2542AA375DC0051274C /* DismissKeyboardTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DismissKeyboardTest.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -89,6 +92,7 @@
 		2F6D139428F5F384007C25D6 /* TestApp */ = {
 			isa = PBXGroup;
 			children = (
+				80A1F42F2D393F3600183BFF /* TestApp.entitlements */,
 				2F273FCA298DC10300FCA397 /* Info.plist */,
 				2FA7382B290ADFAA007ACEB9 /* TestApp.swift */,
 				2F2D337729DE323E00081B1D /* XCTestAppTestCaseTest.swift */,
@@ -96,6 +100,7 @@
 				2F2D338829DE570C00081B1D /* TestAppTestCaseEnum.swift */,
 				2F6D139928F5F386007C25D6 /* Assets.xcassets */,
 				A9E8E2542AA375DC0051274C /* DismissKeyboardTest.swift */,
+				80A1F4302D393F6800183BFF /* HealthKitDataEntry.swift */,
 			);
 			path = TestApp;
 			sourceTree = "<group>";
@@ -226,6 +231,7 @@
 				A9E8E2552AA375DC0051274C /* DismissKeyboardTest.swift in Sources */,
 				2F2D338929DE570C00081B1D /* TestAppTestCaseEnum.swift in Sources */,
 				2F2D337829DE323E00081B1D /* XCTestAppTestCaseTest.swift in Sources */,
+				80A1F4312D393F6800183BFF /* HealthKitDataEntry.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -374,6 +380,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_ENTITLEMENTS = TestApp/TestApp.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "";
@@ -411,6 +418,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_ENTITLEMENTS = TestApp/TestApp.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "";


### PR DESCRIPTION
# fix deletion of HealthKit-connected apps

## :recycle: Current situation & Problem
Deleting an app that has saved data to HealthKit triggers an alert informing the user that the app's health data will remain in the HealthKit database, even when the app is deleted.
This alert is currently not dismissed when deleting an app, which can mess up subsequent queries/interactions/steps in a UITest.

## :gear: Release Notes 
- improve app deletion to handle HealthKit-connected apps


## :books: Documentation
The documentation is unchanged, since this PR doesn't make any changes to the public interface of the package.


## :white_check_mark: Testing
There is a new test case that adds a heart rate sample to the health store, and then deletes the app.


### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).
