### PR TITLE
Improve Timeouts & Checks for App Deletion

### DIFF
--- a/Sources/XCTestExtensions/XCUIApplication+DeleteAndLaunch.swift
+++ b/Sources/XCTestExtensions/XCUIApplication+DeleteAndLaunch.swift
@@ -112,12 +112,16 @@ extension XCUIApplication {
             springboard.alerts["Delete “\(appName)”?"].buttons["Delete"].tap()
 #endif
 
-            // If the app had health data stored, deleting the app will show an alert, which we need to dismiss
+            // If the app had health data stored, deleting the app will show an alert, which we need to dismiss.
+            // We also use this check to provide a 5 second timeout for the app to be deleted.
             let alertTitle = "There is data from “\(appName)” saved in Health"
             if springboard.alerts[alertTitle].waitForExistence(timeout: 5.0) {
                 springboard.alerts[alertTitle].buttons["OK"].tap()
             }
             
+            // Exit the while loop early without a `springboard.icons[appName].firstMatch.waitForExistence(timeout: 10.0)` call.
+            // If the app takes longer to be deleted, this will give it some more time.
+            // Only leads to a delay if we have to delete multiple apps with the same name; otherwise, it exits as soon as the app is removed or even immediately.
             if springboard.icons[appName].waitForNonExistence(timeout: 10.0) {
                 break
             }

--- a/Sources/XCTestExtensions/XCUIApplication+DeleteAndLaunch.swift
+++ b/Sources/XCTestExtensions/XCUIApplication+DeleteAndLaunch.swift
@@ -112,12 +112,13 @@ extension XCUIApplication {
             springboard.alerts["Delete “\(appName)”?"].buttons["Delete"].tap()
 #endif
 
-            if springboard.icons[appName].waitForNonExistence(timeout: 2.0) {
-                // If the app had health data stored, deleting the app will show an alert, which we need to dismiss
-                let alertTitle = "There is data from “\(appName)” saved in Health"
-                if springboard.alerts[alertTitle].waitForExistence(timeout: 2) {
-                    springboard.alerts[alertTitle].buttons["OK"].tap()
-                }
+            // If the app had health data stored, deleting the app will show an alert, which we need to dismiss
+            let alertTitle = "There is data from “\(appName)” saved in Health"
+            if springboard.alerts[alertTitle].waitForExistence(timeout: 5.0) {
+                springboard.alerts[alertTitle].buttons["OK"].tap()
+            }
+            
+            if springboard.icons[appName].waitForNonExistence(timeout: 10.0) {
                 break
             }
         }


### PR DESCRIPTION
# Improve Timeouts & Checks for App Deletion

## :recycle: Current situation & Problem
- We got several reports from UI tests not passing, e.g.,
  - https://github.com/orgs/CS342/discussions/115#discussioncomment-12028403
  - https://github.com/StanfordSpezi/SpeziTemplateApplication/pull/98/files/0a32806a8cecd18d22ce798fe8f9fa11dfeeb150..9d11c271b53579a023382105668cef3c4343e986
- It all seems to be related to a timeout issue that is not waiting for an app the be removed (which might take some time on the CI)
- 
## :gear: Release Notes 
- Improve Timeouts & Checks for App Deletion


### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).
