### PR TITLE
extend XCTestApp API

### DIFF
--- a/Sources/XCTestApp/XCTest.swift
+++ b/Sources/XCTestApp/XCTest.swift
@@ -11,7 +11,7 @@
 public struct XCTestFailure: Error, CustomStringConvertible {
     let message: String
     let file: StaticString
-    let line: Int
+    let line: UInt
     
     
     public var description: String {
@@ -24,7 +24,7 @@ public struct XCTestFailure: Error, CustomStringConvertible {
     ///   - message: An optional description of a failure.
     ///   - file: The file where the failure occurs. The default is the filename of the test case where you call this function.
     ///   - line: The line number where the failure occurs. The default is the line number where you call this function.
-    public init(message: String = "", file: StaticString = #file, line: Int = #line) {
+    public init(message: String = "", file: StaticString = #filePath, line: UInt = #line) {
         self.message = message
         self.file = file
         self.line = line
@@ -41,11 +41,42 @@ public struct XCTestFailure: Error, CustomStringConvertible {
 ///   - file: The file where the failure occurs. The default is the filename of the test case where you call this function.
 ///   - line: The line number where the failure occurs. The default is the line number where you call this function.
 /// - Throws: This function throws an ``XCTestFailure`` failure when `expression == false`.
-public func XCTAssert(_ condition: @autoclosure () -> Bool, message: String = "", file: StaticString = #file, line: Int = #line) throws {
+public func XCTAssert(_ condition: @autoclosure () -> Bool, message: String = "", file: StaticString = #filePath, line: UInt = #line) throws {
+    try XCTAssertTrue(condition(), message: message, file: file, line: line)
+}
+
+
+/// Asserts that an expression is true.
+///
+/// This function generates a failure when `expression == false`.
+/// - Parameters:
+///   - condition: An expression of Boolean type.
+///   - message: An optional description of a failure.
+///   - file: The file where the failure occurs. The default is the filename of the test case where you call this function.
+///   - line: The line number where the failure occurs. The default is the line number where you call this function.
+/// - Throws: This function throws an ``XCTestFailure`` failure when `expression == false`.
+public func XCTAssertTrue(_ condition: @autoclosure () -> Bool, message: String = "", file: StaticString = #filePath, line: UInt = #line) throws {
     guard condition() else {
         throw XCTestFailure(message: message, file: file, line: line)
     }
 }
+
+
+/// Asserts that an expression is false.
+///
+/// This function generates a failure when `expression == true`.
+/// - Parameters:
+///   - condition: An expression of Boolean type.
+///   - message: An optional description of a failure.
+///   - file: The file where the failure occurs. The default is the filename of the test case where you call this function.
+///   - line: The line number where the failure occurs. The default is the line number where you call this function.
+/// - Throws: This function throws an ``XCTestFailure`` failure when `expression == false`.
+public func XCTAssertFalse(_ condition: @autoclosure () -> Bool, message: String = "", file: StaticString = #filePath, line: UInt = #line) throws {
+    guard !condition() else {
+        throw XCTestFailure(message: message, file: file, line: line)
+    }
+}
+
 
 /// Asserts that two values are equal.
 ///
@@ -57,8 +88,25 @@ public func XCTAssert(_ condition: @autoclosure () -> Bool, message: String = ""
 ///   - file: The file where the failure occurs. The default is the filename of the test case where you call this function.
 ///   - line: The line number where the failure occurs. The default is the line number where you call this function.
 /// - Throws: This function throws an ``XCTestFailure`` failure when `lhs` and `rhs` are not equal.
-public func XCTAssertEqual<E: Equatable>(_ lhs: E, _ rhs: E, message: String = "", file: StaticString = #file, line: Int = #line) throws {
+public func XCTAssertEqual<E: Equatable>(_ lhs: E, _ rhs: E, message: String = "", file: StaticString = #filePath, line: UInt = #line) throws {
     guard lhs == rhs else {
+        throw XCTestFailure(message: message, file: file, line: line)
+    }
+}
+
+
+/// Asserts that two values are not equal.
+///
+/// Use this function to compare two non-optional values of the same type.
+/// - Parameters:
+///   - lhs: An expression of type `T`, where `T` is `Equatable`.
+///   - rhs: A second expression of type `T`, where `T` is `Equatable`.
+///   - message: An optional description of a failure.
+///   - file: The file where the failure occurs. The default is the filename of the test case where you call this function.
+///   - line: The line number where the failure occurs. The default is the line number where you call this function.
+/// - Throws: This function throws an ``XCTestFailure`` failure when `lhs` and `rhs` are equal.
+public func XCTAssertNotEqual<E: Equatable>(_ lhs: E, _ rhs: E, message: String = "", file: StaticString = #filePath, line: UInt = #line) throws {
+    guard lhs != rhs else {
         throw XCTestFailure(message: message, file: file, line: line)
     }
 }
@@ -73,8 +121,24 @@ public func XCTAssertEqual<E: Equatable>(_ lhs: E, _ rhs: E, message: String = "
 ///   - file: The file where the failure occurs. The default is the filename of the test case where you call this function.
 ///   - line: The line number where the failure occurs. The default is the line number where you call this function.
 /// - Throws: This function throws an ``XCTestFailure`` failure when `expression != nil`.
-public func XCTAssertNil<O>(_ optional: O?, message: String = "", file: StaticString = #file, line: Int = #line) throws {
+public func XCTAssertNil<O>(_ optional: O?, message: String = "", file: StaticString = #filePath, line: UInt = #line) throws {
     guard optional == nil else {
+        throw XCTestFailure(message: message, file: file, line: line)
+    }
+}
+
+
+/// Asserts that an expression is not nil.
+///
+/// This function generates a failure when `expression == nil`.
+/// - Parameters:
+///   - optional: An expression of type `Optional` to compare against nil.
+///   - message: An optional description of a failure.
+///   - file: The file where the failure occurs. The default is the filename of the test case where you call this function.
+///   - line: The line number where the failure occurs. The default is the line number where you call this function.
+/// - Throws: This function throws an ``XCTestFailure`` failure when `expression != nil`.
+public func XCTAssertNotNil<O>(_ optional: O?, message: String = "", file: StaticString = #filePath, line: UInt = #line) throws {
+    guard optional != nil else {
         throw XCTestFailure(message: message, file: file, line: line)
     }
 }
@@ -90,7 +154,7 @@ public func XCTAssertNil<O>(_ optional: O?, message: String = "", file: StaticSt
 ///   - line: The line number where the failure occurs. The default is the line number where you call this function.
 /// - Throws: This function throws an ``XCTestFailure`` failure when expression is not `nil`.
 /// - Returns: The result of evaluating and unwrapping the expression, which is of type `T`. `XCTUnwrap()` only returns a value if expression is not `nil`.
-public func XCTUnwrap<O>(_ optional: O?, message: String = "", file: StaticString = #file, line: Int = #line) throws -> O {
+public func XCTUnwrap<O>(_ optional: O?, message: String = "", file: StaticString = #filePath, line: UInt = #line) throws -> O {
     guard let unwrapped = optional else {
         throw XCTestFailure(message: message, file: file, line: line)
     }

--- a/Sources/XCTestApp/XCTest.swift
+++ b/Sources/XCTestApp/XCTest.swift
@@ -47,7 +47,13 @@ public func XCTAssert(
     file: StaticString = #filePath,
     line: UInt = #line
 ) throws {
-    try XCTAssertTrue(condition(), message: message(), file: file, line: line)
+    guard condition() else {
+        throw XCTestFailure(
+            message: formatFailureMessage(baseText: "", additionalMessage: message()),
+            file: file,
+            line: line
+        )
+    }
 }
 
 
@@ -67,7 +73,11 @@ public func XCTAssertTrue(
     line: UInt = #line
 ) throws {
     guard condition() else {
-        throw XCTestFailure(message: message(), file: file, line: line)
+        throw XCTestFailure(
+            message: formatFailureMessage(baseText: "", additionalMessage: message()),
+            file: file,
+            line: line
+        )
     }
 }
 
@@ -88,7 +98,11 @@ public func XCTAssertFalse(
     line: UInt = #line
 ) throws {
     guard !condition() else {
-        throw XCTestFailure(message: message(), file: file, line: line)
+        throw XCTestFailure(
+            message: formatFailureMessage(baseText: "", additionalMessage: message()),
+            file: file,
+            line: line
+        )
     }
 }
 
@@ -103,15 +117,19 @@ public func XCTAssertFalse(
 ///   - file: The file where the failure occurs. The default is the filename of the test case where you call this function.
 ///   - line: The line number where the failure occurs. The default is the line number where you call this function.
 /// - Throws: This function throws an ``XCTestFailure`` failure when `lhs` and `rhs` are not equal.
-public func XCTAssertEqual<E: Equatable>(
-    _ lhs: E,
-    _ rhs: E,
+public func XCTAssertEqual<T: Equatable>(
+    _ lhs: T,
+    _ rhs: T,
     message: @autoclosure () -> String = "",
     file: StaticString = #filePath,
     line: UInt = #line
 ) throws {
     guard lhs == rhs else {
-        throw XCTestFailure(message: message(), file: file, line: line)
+        throw XCTestFailure(
+            message: formatFailureMessage(baseText: "'\(lhs)' is not equal to '\(rhs)'", additionalMessage: message()),
+            file: file,
+            line: line
+        )
     }
 }
 
@@ -126,15 +144,19 @@ public func XCTAssertEqual<E: Equatable>(
 ///   - file: The file where the failure occurs. The default is the filename of the test case where you call this function.
 ///   - line: The line number where the failure occurs. The default is the line number where you call this function.
 /// - Throws: This function throws an ``XCTestFailure`` failure when `lhs` and `rhs` are equal.
-public func XCTAssertNotEqual<E: Equatable>(
-    _ lhs: E,
-    _ rhs: E,
+public func XCTAssertNotEqual<T: Equatable>(
+    _ lhs: T,
+    _ rhs: T,
     message: @autoclosure () -> String = "",
     file: StaticString = #filePath,
     line: UInt = #line
 ) throws {
     guard lhs != rhs else {
-        throw XCTestFailure(message: message(), file: file, line: line)
+        throw XCTestFailure(
+            message: formatFailureMessage(baseText: "'\(lhs)' is equal to '\(rhs)'", additionalMessage: message()),
+            file: file,
+            line: line
+        )
     }
 }
 
@@ -143,19 +165,23 @@ public func XCTAssertNotEqual<E: Equatable>(
 ///
 /// This function generates a failure when `expression != nil`.
 /// - Parameters:
-///   - optional: An expression of type `Optional` to compare against nil.
+///   - expression: An expression to compare against `nil`.
 ///   - message: An optional description of a failure.
 ///   - file: The file where the failure occurs. The default is the filename of the test case where you call this function.
 ///   - line: The line number where the failure occurs. The default is the line number where you call this function.
 /// - Throws: This function throws an ``XCTestFailure`` failure when `expression != nil`.
-public func XCTAssertNil<O>(
-    _ optional: O?,
+public func XCTAssertNil(
+    _ expression: (some Any)?,
     message: @autoclosure () -> String = "",
     file: StaticString = #filePath,
     line: UInt = #line
 ) throws {
-    guard optional == nil else {
-        throw XCTestFailure(message: message(), file: file, line: line)
+    if let value = expression {
+        throw XCTestFailure(
+            message: formatFailureMessage(baseText: "'\(value)'", additionalMessage: message()),
+            file: file,
+            line: line
+        )
     }
 }
 
@@ -164,19 +190,23 @@ public func XCTAssertNil<O>(
 ///
 /// This function generates a failure when `expression == nil`.
 /// - Parameters:
-///   - optional: An expression of type `Optional` to compare against nil.
+///   - expression: An expression to compare against `nil`.
 ///   - message: An optional description of a failure.
 ///   - file: The file where the failure occurs. The default is the filename of the test case where you call this function.
 ///   - line: The line number where the failure occurs. The default is the line number where you call this function.
 /// - Throws: This function throws an ``XCTestFailure`` failure when `expression != nil`.
-public func XCTAssertNotNil<O>(
-    _ optional: O?,
+public func XCTAssertNotNil(
+    _ expression: (some Any)?,
     message: @autoclosure () -> String = "",
     file: StaticString = #filePath,
     line: UInt = #line
 ) throws {
-    guard optional != nil else {
-        throw XCTestFailure(message: message(), file: file, line: line)
+    if expression == nil {
+        throw XCTestFailure(
+            message: formatFailureMessage(baseText: "", additionalMessage: message()),
+            file: file,
+            line: line
+        )
     }
 }
 
@@ -191,14 +221,18 @@ public func XCTAssertNotNil<O>(
 ///   - line: The line number where the failure occurs. The default is the line number where you call this function.
 /// - Throws: This function throws an ``XCTestFailure`` failure when expression is not `nil`.
 /// - Returns: The result of evaluating and unwrapping the expression, which is of type `T`. `XCTUnwrap()` only returns a value if expression is not `nil`.
-public func XCTUnwrap<O>(
-    _ optional: O?,
+public func XCTUnwrap<T>(
+    _ optional: T?,
     message: @autoclosure () -> String = "",
     file: StaticString = #filePath,
     line: UInt = #line
-) throws -> O {
+) throws -> T {
     guard let unwrapped = optional else {
-        throw XCTestFailure(message: message(), file: file, line: line)
+        throw XCTestFailure(
+            message: formatFailureMessage(baseText: "Expected non-nil value of type '\(T.self)'", additionalMessage: message()),
+            file: file,
+            line: line
+        )
     }
     return unwrapped
 }
@@ -208,7 +242,7 @@ public func XCTUnwrap<O>(
 ///
 /// This function generates a failure when the expression does throw an error.
 /// - Parameters:
-///   - optional: An expression that can throw an error.
+///   - expression: An expression that can throw an error.
 ///   - message: An optional description of a failure.
 ///   - file: The file where the failure occurs. The default is the filename of the test case where you call this function.
 ///   - line: The line number where the failure occurs. The default is the line number where you call this function.
@@ -222,6 +256,25 @@ public func XCTAssertNoThrow(
     do {
         _ = try expression()
     } catch {
-        throw XCTestFailure(message: message(), file: file, line: line)
+        throw XCTestFailure(
+            message: formatFailureMessage(baseText: "threw error '\(error)'", additionalMessage: message()),
+            file: file,
+            line: line
+        )
     }
+}
+
+
+// MARK: Utilities
+
+private func formatFailureMessage(_ caller: String = #function, baseText: String, additionalMessage: String) -> String {
+    let caller = caller.firstIndex(of: "(").map { caller[caller.startIndex..<$0] } ?? caller[...]
+    var msg = "\(caller) failed"
+    if !baseText.isEmpty {
+        msg += ": \(baseText)"
+    }
+    if !additionalMessage.isEmpty {
+        msg += " — \(additionalMessage)"
+    }
+    return msg
 }

--- a/Sources/XCTestApp/XCTest.swift
+++ b/Sources/XCTestApp/XCTest.swift
@@ -41,8 +41,13 @@ public struct XCTestFailure: Error, CustomStringConvertible {
 ///   - file: The file where the failure occurs. The default is the filename of the test case where you call this function.
 ///   - line: The line number where the failure occurs. The default is the line number where you call this function.
 /// - Throws: This function throws an ``XCTestFailure`` failure when `expression == false`.
-public func XCTAssert(_ condition: @autoclosure () -> Bool, message: String = "", file: StaticString = #filePath, line: UInt = #line) throws {
-    try XCTAssertTrue(condition(), message: message, file: file, line: line)
+public func XCTAssert(
+    _ condition: @autoclosure () -> Bool,
+    message: @autoclosure () -> String = "",
+    file: StaticString = #filePath,
+    line: UInt = #line
+) throws {
+    try XCTAssertTrue(condition(), message: message(), file: file, line: line)
 }
 
 
@@ -55,9 +60,14 @@ public func XCTAssert(_ condition: @autoclosure () -> Bool, message: String = ""
 ///   - file: The file where the failure occurs. The default is the filename of the test case where you call this function.
 ///   - line: The line number where the failure occurs. The default is the line number where you call this function.
 /// - Throws: This function throws an ``XCTestFailure`` failure when `expression == false`.
-public func XCTAssertTrue(_ condition: @autoclosure () -> Bool, message: String = "", file: StaticString = #filePath, line: UInt = #line) throws {
+public func XCTAssertTrue(
+    _ condition: @autoclosure () -> Bool,
+    message: @autoclosure () -> String = "",
+    file: StaticString = #filePath,
+    line: UInt = #line
+) throws {
     guard condition() else {
-        throw XCTestFailure(message: message, file: file, line: line)
+        throw XCTestFailure(message: message(), file: file, line: line)
     }
 }
 
@@ -71,9 +81,14 @@ public func XCTAssertTrue(_ condition: @autoclosure () -> Bool, message: String 
 ///   - file: The file where the failure occurs. The default is the filename of the test case where you call this function.
 ///   - line: The line number where the failure occurs. The default is the line number where you call this function.
 /// - Throws: This function throws an ``XCTestFailure`` failure when `expression == false`.
-public func XCTAssertFalse(_ condition: @autoclosure () -> Bool, message: String = "", file: StaticString = #filePath, line: UInt = #line) throws {
+public func XCTAssertFalse(
+    _ condition: @autoclosure () -> Bool,
+    message: @autoclosure () -> String = "",
+    file: StaticString = #filePath,
+    line: UInt = #line
+) throws {
     guard !condition() else {
-        throw XCTestFailure(message: message, file: file, line: line)
+        throw XCTestFailure(message: message(), file: file, line: line)
     }
 }
 
@@ -88,9 +103,15 @@ public func XCTAssertFalse(_ condition: @autoclosure () -> Bool, message: String
 ///   - file: The file where the failure occurs. The default is the filename of the test case where you call this function.
 ///   - line: The line number where the failure occurs. The default is the line number where you call this function.
 /// - Throws: This function throws an ``XCTestFailure`` failure when `lhs` and `rhs` are not equal.
-public func XCTAssertEqual<E: Equatable>(_ lhs: E, _ rhs: E, message: String = "", file: StaticString = #filePath, line: UInt = #line) throws {
+public func XCTAssertEqual<E: Equatable>(
+    _ lhs: E,
+    _ rhs: E,
+    message: @autoclosure () -> String = "",
+    file: StaticString = #filePath,
+    line: UInt = #line
+) throws {
     guard lhs == rhs else {
-        throw XCTestFailure(message: message, file: file, line: line)
+        throw XCTestFailure(message: message(), file: file, line: line)
     }
 }
 
@@ -105,9 +126,15 @@ public func XCTAssertEqual<E: Equatable>(_ lhs: E, _ rhs: E, message: String = "
 ///   - file: The file where the failure occurs. The default is the filename of the test case where you call this function.
 ///   - line: The line number where the failure occurs. The default is the line number where you call this function.
 /// - Throws: This function throws an ``XCTestFailure`` failure when `lhs` and `rhs` are equal.
-public func XCTAssertNotEqual<E: Equatable>(_ lhs: E, _ rhs: E, message: String = "", file: StaticString = #filePath, line: UInt = #line) throws {
+public func XCTAssertNotEqual<E: Equatable>(
+    _ lhs: E,
+    _ rhs: E,
+    message: @autoclosure () -> String = "",
+    file: StaticString = #filePath,
+    line: UInt = #line
+) throws {
     guard lhs != rhs else {
-        throw XCTestFailure(message: message, file: file, line: line)
+        throw XCTestFailure(message: message(), file: file, line: line)
     }
 }
 
@@ -121,9 +148,14 @@ public func XCTAssertNotEqual<E: Equatable>(_ lhs: E, _ rhs: E, message: String 
 ///   - file: The file where the failure occurs. The default is the filename of the test case where you call this function.
 ///   - line: The line number where the failure occurs. The default is the line number where you call this function.
 /// - Throws: This function throws an ``XCTestFailure`` failure when `expression != nil`.
-public func XCTAssertNil<O>(_ optional: O?, message: String = "", file: StaticString = #filePath, line: UInt = #line) throws {
+public func XCTAssertNil<O>(
+    _ optional: O?,
+    message: @autoclosure () -> String = "",
+    file: StaticString = #filePath,
+    line: UInt = #line
+) throws {
     guard optional == nil else {
-        throw XCTestFailure(message: message, file: file, line: line)
+        throw XCTestFailure(message: message(), file: file, line: line)
     }
 }
 
@@ -137,9 +169,14 @@ public func XCTAssertNil<O>(_ optional: O?, message: String = "", file: StaticSt
 ///   - file: The file where the failure occurs. The default is the filename of the test case where you call this function.
 ///   - line: The line number where the failure occurs. The default is the line number where you call this function.
 /// - Throws: This function throws an ``XCTestFailure`` failure when `expression != nil`.
-public func XCTAssertNotNil<O>(_ optional: O?, message: String = "", file: StaticString = #filePath, line: UInt = #line) throws {
+public func XCTAssertNotNil<O>(
+    _ optional: O?,
+    message: @autoclosure () -> String = "",
+    file: StaticString = #filePath,
+    line: UInt = #line
+) throws {
     guard optional != nil else {
-        throw XCTestFailure(message: message, file: file, line: line)
+        throw XCTestFailure(message: message(), file: file, line: line)
     }
 }
 
@@ -154,9 +191,14 @@ public func XCTAssertNotNil<O>(_ optional: O?, message: String = "", file: Stati
 ///   - line: The line number where the failure occurs. The default is the line number where you call this function.
 /// - Throws: This function throws an ``XCTestFailure`` failure when expression is not `nil`.
 /// - Returns: The result of evaluating and unwrapping the expression, which is of type `T`. `XCTUnwrap()` only returns a value if expression is not `nil`.
-public func XCTUnwrap<O>(_ optional: O?, message: String = "", file: StaticString = #filePath, line: UInt = #line) throws -> O {
+public func XCTUnwrap<O>(
+    _ optional: O?,
+    message: @autoclosure () -> String = "",
+    file: StaticString = #filePath,
+    line: UInt = #line
+) throws -> O {
     guard let unwrapped = optional else {
-        throw XCTestFailure(message: message, file: file, line: line)
+        throw XCTestFailure(message: message(), file: file, line: line)
     }
     return unwrapped
 }

--- a/Sources/XCTestApp/XCTest.swift
+++ b/Sources/XCTestApp/XCTest.swift
@@ -267,7 +267,11 @@ public func XCTAssertNoThrow(
 
 // MARK: Utilities
 
-private func formatFailureMessage(_ caller: String = #function, baseText: String, additionalMessage: String) -> String {
+private func formatFailureMessage(
+    _ caller: String = #function, // swiftlint:disable:this function_default_parameter_at_end
+    baseText: String,
+    additionalMessage: String
+) -> String {
     let caller = caller.firstIndex(of: "(").map { caller[caller.startIndex..<$0] } ?? caller[...]
     var msg = "\(caller) failed"
     if !baseText.isEmpty {

--- a/Sources/XCTestApp/XCTest.swift
+++ b/Sources/XCTestApp/XCTest.swift
@@ -202,3 +202,26 @@ public func XCTUnwrap<O>(
     }
     return unwrapped
 }
+
+
+/// Asserts that an expression doesn’t throw an error.
+///
+/// This function generates a failure when the expression does throw an error.
+/// - Parameters:
+///   - optional: An expression that can throw an error.
+///   - message: An optional description of a failure.
+///   - file: The file where the failure occurs. The default is the filename of the test case where you call this function.
+///   - line: The line number where the failure occurs. The default is the line number where you call this function.
+/// - Throws: This function throws an ``XCTestFailure`` failure when `expression` throws an error.
+public func XCTAssertNoThrow(
+    _ expression: @autoclosure () throws -> some Any,
+    _ message: @autoclosure () -> String = "",
+    file: StaticString = #filePath,
+    line: UInt = #line
+) throws {
+    do {
+        _ = try expression()
+    } catch {
+        throw XCTestFailure(message: message(), file: file, line: line)
+    }
+}

--- a/Tests/UITests/TestApp/XCTestAppTestCaseTest.swift
+++ b/Tests/UITests/TestApp/XCTestAppTestCaseTest.swift
@@ -18,6 +18,7 @@ struct XCTestAppTestCaseTest: TestAppTestCase {
         try await testAssertNil()
         try await testAssertNotNil()
         try testAssertUnwrap()
+        try testNoThrow()
     }
     
     
@@ -85,6 +86,17 @@ struct XCTestAppTestCaseTest: TestAppTestCase {
         print(try XCTUnwrap(42))
         try assertThrows {
             _ = try XCTUnwrap(Optional<Int>.none)
+        }
+    }
+    
+    
+    func testNoThrow() throws {
+        struct FakeError: Error {}
+        try XCTAssertNoThrow({ () throws -> Void in }())
+        try assertThrows {
+            try XCTAssertNoThrow({ () throws -> Void in
+                throw FakeError()
+            }())
         }
     }
 }

--- a/Tests/UITests/TestApp/XCTestAppTestCaseTest.swift
+++ b/Tests/UITests/TestApp/XCTestAppTestCaseTest.swift
@@ -74,7 +74,7 @@ struct XCTestAppTestCaseTest: TestAppTestCase {
     
     
     func testAssertNotNil() async throws {
-        try XCTAssertNotNil(Optional<Int>.some(52))
+        try XCTAssertNotNil(52)
         try assertThrows {
             try XCTAssertNotNil(Optional<Void>.none)
         }
@@ -92,9 +92,9 @@ struct XCTestAppTestCaseTest: TestAppTestCase {
     
     func testNoThrow() throws {
         struct FakeError: Error {}
-        try XCTAssertNoThrow({ () throws -> Void in }())
+        try XCTAssertNoThrow({ () throws in }())
         try assertThrows {
-            try XCTAssertNoThrow({ () throws -> Void in
+            try XCTAssertNoThrow({ () throws in
                 throw FakeError()
             }())
         }

--- a/Tests/UITests/TestApp/XCTestAppTestCaseTest.swift
+++ b/Tests/UITests/TestApp/XCTestAppTestCaseTest.swift
@@ -14,49 +14,77 @@ struct XCTestAppTestCaseTest: TestAppTestCase {
     func runTests() async throws {
         try testAssert()
         try await testAssertEqual()
+        try await testAssertNotEqual()
         try await testAssertNil()
+        try await testAssertNotNil()
         try testAssertUnwrap()
     }
     
-    func testAssert() throws {
-        try XCTAssert(true)
-        
+    
+    private func assertThrows(_ block: () throws -> Void, file: StaticString = #filePath, line: UInt = #line) throws {
         do {
-            try XCTAssert(false)
-            throw XCTestFailure(message: "Did not trigger the expected assertion.")
+            try block()
+            throw XCTestFailure(message: "Did not trigger the expected assertion.", file: file, line: line)
         } catch { }
     }
+    
+    
+    func testAssert() throws {
+        try XCTAssert(true)
+        try XCTAssertTrue(true)
+        try XCTAssertFalse(false)
+        try assertThrows {
+            try XCTAssert(false)
+        }
+        try assertThrows {
+            try XCTAssertTrue(false)
+        }
+        try assertThrows {
+            try XCTAssertFalse(true)
+        }
+    }
+    
     
     func testAssertEqual() async throws {
         try await Task.sleep(for: .seconds(0.1))
-        
-        
         try XCTAssertEqual(42, 42)
-        
-        do {
+        try assertThrows {
             try XCTAssertEqual(42, 43)
-            throw XCTestFailure(message: "Did not trigger the expected assertion.")
-        } catch { }
+        }
     }
+    
+    
+    func testAssertNotEqual() async throws {
+        try await Task.sleep(for: .seconds(0.1))
+        try XCTAssertNotEqual(42, 43)
+        try assertThrows {
+            try XCTAssertNotEqual(42, 42)
+        }
+    }
+    
     
     func testAssertNil() async throws {
         try XCTAssertNil(Optional<Int>.none)
-        
-        do {
+        try assertThrows {
             try XCTAssertNil(42)
-            throw XCTestFailure(message: "Did not trigger the expected assertion.")
-        } catch { }
-        
-        
+        }
         try await Task.sleep(for: .seconds(0.1))
     }
     
+    
+    func testAssertNotNil() async throws {
+        try XCTAssertNotNil(Optional<Int>.some(52))
+        try assertThrows {
+            try XCTAssertNotNil(Optional<Void>.none)
+        }
+        try await Task.sleep(for: .seconds(0.1))
+    }
+    
+    
     func testAssertUnwrap() throws {
         print(try XCTUnwrap(42))
-        
-        do {
+        try assertThrows {
             _ = try XCTUnwrap(Optional<Int>.none)
-            throw XCTestFailure(message: "Did not trigger the expected assertion.")
-        } catch { }
+        }
     }
 }


### PR DESCRIPTION
# extend XCTestApp API

## :recycle: Current situation & Problem
- The XCTestApp target currently implements a handful of `XCTAssertX` functions, but several key ones are missing.
  - We add the following: `XCTAssertTrue`, `XCTAssertFalse`, `XCTAssertNotEqual`, `XCTAssertNotNil`, `XCTAssertNoThrow`


## :gear: Release Notes 
Added several `XCTAssert...` functions to the XCTestApp API: `XCTAssertTrue`, `XCTAssertFalse`, `XCTAssertNotEqual`, `XCTAssertNotNil`, and `XCTAssertNoThrow`


## :books: Documentation
All new code is documented, based on how the existing functions are documented.


## :white_check_mark: Testing
All new code is tested based on how the existing functions are tested.

### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).
