### PR TITLE
add predicate utils

### DIFF
--- a/Sources/XCTestExtensions/XCUIElement+Predicates.swift
+++ b/Sources/XCTestExtensions/XCUIElement+Predicates.swift
@@ -1,0 +1,42 @@
+//
+// This source file is part of the Stanford XCTestExtensions open-source project
+//
+// SPDX-FileCopyrightText: 2026 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+import XCTest
+
+
+extension XCUIElementQuery {
+    /// Returns a new query that matches elements that meet the logical conditions of the provided predicate.
+    ///
+    /// - Note: This function is identical to `-[XCUIElementQuery matchingPredicate:]`, except that it takes a `String` and then implicitly creates an `NSPredicate` from that.
+    ///
+    /// - parameter predicateFormat: The predicate's format string
+    /// - parameter args: The arguments that are substited into the predicate
+    public func matching(_ predicateFormat: String, _ args: Any...) -> XCUIElementQuery {
+        self.matching(NSPredicate(format: predicateFormat, argumentArray: args))
+    }
+    
+    /// Matches the predicate.
+    ///
+    /// - Note: This function is identical to `-[XCUIElementQuery elementMatchingPredicate:]`, except that it takes a `String` and then implicitly creates an `NSPredicate` from that.
+    ///
+    /// - parameter predicateFormat: The predicate's format string
+    /// - parameter args: The arguments that are substited into the predicate
+    public func element(matching predicateFormat: String, _ args: Any...) -> XCUIElement {
+        self.element(matching: NSPredicate(format: predicateFormat, argumentArray: args))
+    }
+    
+    /// Returns a new query that matches elements containing a descendant that meets the logical conditions of the provided predicate.
+    ///
+    /// - Note: This function is identical to `-[XCUIElementQuery containingPredicate:]`, except that it takes a `String` and then implicitly creates an `NSPredicate` from that.
+    ///
+    /// - parameter predicateFormat: The predicate's format string
+    /// - parameter args: The arguments that are substited into the predicate
+    public func containing(_ predicateFormat: String, _ args: Any...) -> XCUIElementQuery {
+        self.containing(NSPredicate(format: predicateFormat, argumentArray: args))
+    }
+}


### PR DESCRIPTION
# add predicate utils


## :gear: Release Notes
- adds shorthand methods for working with NSPredicate-based queries


## :books: Documentation
yes


## :white_check_mark: Testing
n/a


### Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added three convenience methods for UI element query construction using string-based predicate formats. The new `matching()`, `element(matching:)`, and `containing()` methods simplify predicate creation with format strings and arguments in test scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->